### PR TITLE
Add support for ansible galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: Jonas Alfredsson
+  description: Ansible role to install and configure Kea DHCP server
+  license: GPL-3.0-or-later
+  min_ansible_version: 2.9
+  platforms:
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
+    - name: CentOS
+      versions:
+        - 7
+        - 8
+  galaxy_tags:
+    - kea
+    - dhcp
+    - isc
+    - network

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ galaxy_info:
   description: Ansible role to install and configure Kea DHCP server
   license: GPL-3.0-or-later
   min_ansible_version: 2.9
+  role_name: kea
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Add support to publish the role to ansible galaxy and prevent error when using the role from the source git repository in a requirements.yml file.