### PR TITLE
Fix container crashing due to wrong permissions on sockets directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
   ansible.builtin.file:
     state: directory
     path: "{{ item }}"
-    mode: '0775'
+    mode: '0750'
     owner: 'root'
     group: '101'
   loop:


### PR DESCRIPTION
This pull request fixes both the ctrl-agent and dhcp4 container crashing because of this error:

```bash
2025-09-08 13:35:32.814 ERROR [kea-dhcp4.dhcp4/1.128197017878784] DHCP4_CONFIG_LOAD_FAIL configuration error using file: /kea/config/dhcp4.json, reason: 'socket-name' is invalid: socket path:/kea/sockets does not exist or does not have permssions = 750
2025-09-08 13:35:32.814 ERROR [kea-dhcp4.dhcp4/1.128197017878784] DHCP4_INIT_FAIL failed to initialize Kea server: configuration error using file '/kea/config/dhcp4.json': 'socket-name' is invalid: socket path:/kea/sockets does not exist or does not have permssions = 750

```